### PR TITLE
`fs::File`-like objects v2

### DIFF
--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -223,6 +223,10 @@ impl Registry {
         })
     }
 
+    pub fn access(&self, path: &Path) -> Result<()> {
+        self.get(path).map(|_| {})
+    }
+
     pub fn set_mode(&mut self, path: &Path, mode: u32) -> Result<()> {
         self.get_mut(path).map(|node| match node {
             Node::File(ref mut file) => file.mode = mode,

--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -124,8 +124,13 @@ impl Registry {
     }
 
     pub fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
+        self.read_file_ref(path)
+            .map(|c| c.to_vec())
+    }
+
+    pub fn read_file_ref(&self, path: &Path) -> Result<&Vec<u8>> {
         match self.get_file(path) {
-            Ok(f) if f.mode & 0o444 != 0 => Ok(f.contents.clone()),
+            Ok(f) if f.mode & 0o444 != 0 => Ok(&f.contents),
             Ok(_) => Err(create_error(ErrorKind::PermissionDenied)),
             Err(err) => Err(err),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,9 @@ extern crate rand;
 extern crate tempdir;
 
 use std::ffi::OsString;
-use std::io::Result;
+use std::io::{self, Result};
 use std::path::{Path, PathBuf};
+use std::fmt;
 
 #[cfg(feature = "fake")]
 pub use fake::{FakeFileSystem, FakeTempDir};
@@ -27,6 +28,7 @@ mod os;
 pub trait FileSystem {
     type DirEntry: DirEntry;
     type ReadDir: ReadDir<Self::DirEntry>;
+    type OpenFile: io::Read + fmt::Debug;
 
     /// Returns the current working directory.
     /// This is based on [`std::env::current_dir`].
@@ -112,6 +114,11 @@ pub trait FileSystem {
     /// * `path` is a directory.
     /// * Current user has insufficient permissions.
     fn read_file<P: AsRef<Path>>(&self, path: P) -> Result<Vec<u8>>;
+    /// Attempts to open a file in read-only mode.
+    ///
+    /// The returned handle implements the `io::Read` trait, so it
+    /// can be used to read the file in a stream-like fashion.
+    fn open<P: AsRef<Path>>(&self, path: P) -> Result<Self::OpenFile>;
     /// Returns the contents of `path` as a string.
     ///
     /// # Errors

--- a/src/os.rs
+++ b/src/os.rs
@@ -48,6 +48,7 @@ impl OsFileSystem {
 impl FileSystem for OsFileSystem {
     type DirEntry = fs::DirEntry;
     type ReadDir = fs::ReadDir;
+    type OpenFile = File;
 
     fn current_dir(&self) -> Result<PathBuf> {
         env::current_dir()
@@ -110,6 +111,10 @@ impl FileSystem for OsFileSystem {
         file.read_to_end(&mut contents)?;
 
         Ok(contents)
+    }
+
+    fn open<P: AsRef<Path>>(&self, path: P) -> Result<Self::OpenFile> {
+        File::open(path)
     }
 
     fn read_file_into<P, B>(&self, path: P, mut buf: B) -> Result<usize>


### PR DESCRIPTION
Support `fs::File`-like objects

Support opening and reading files in the same way as Rust's
`fs::File` API, which allows multiple I/O operations via a
`File`-like object.

Example:
```rust
let reader = fs.open(&path); // fs::File::open(&path) on stdlib
let mut buf = vec![0; 4];
reader.read_exact(&mut buf)?;
let mut buf = vec![];
reader.read_to_end(&mut buf)?;
```

Only the `io::Read` trait is currently supported. Extra functionality
such as `io::Write` / `io::Seek` could be added later, if there is
interest.