### PR TITLE
Replace Weak Registry refs

### DIFF
--- a/src/fake/mod.rs
+++ b/src/fake/mod.rs
@@ -299,7 +299,7 @@ impl TempFileSystem for FakeFileSystem {
 
     fn temp_dir<S: AsRef<str>>(&self, prefix: S) -> Result<Self::TempDir> {
         let base = env::temp_dir();
-        let dir = FakeTempDir::new(Arc::downgrade(&self.registry), &base, prefix.as_ref());
+        let dir = FakeTempDir::new(self.registry.clone(), &base, prefix.as_ref());
 
         self.create_dir_all(&dir.path()).and(Ok(dir))
     }

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -136,6 +136,7 @@ macro_rules! test_fs {
 
             make_test!(temp_dir_creates_tempdir, $fs);
             make_test!(temp_dir_creates_unique_dir, $fs);
+            make_test!(temp_dir_disappears, $fs);
         }
     };
 }
@@ -1132,4 +1133,20 @@ fn temp_dir_creates_unique_dir<T: FileSystem + TempFileSystem>(fs: &T, _: &Path)
     let second = fs.temp_dir("test").unwrap();
 
     assert_ne!(first.path(), second.path());
+}
+
+fn temp_dir_disappears<T: FileSystem + TempFileSystem>(fs: &T, _: &Path) {
+    let temp_dir = fs.temp_dir("test").unwrap();
+    let temp_dir_path = temp_dir.path().to_path_buf();
+
+    // verify that it's there
+    let result = fs.read_dir(&temp_dir_path);
+    assert!(result.is_ok());
+
+    // drop the temp dir to delete it
+    drop(temp_dir);
+
+    // verify that it's gone
+    let result = fs.read_dir(&temp_dir_path);
+    assert!(result.is_err());
 }


### PR DESCRIPTION
Check with Isobel if Weak Registry refs can be replaced with existing Arc Registry refs.

There's no way for me to know if I'm unaware of the use case.