### PR TITLE
Fix `fake` only build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ rust:
 nofications:
   email: false
 script:
+  - cargo build --no-default-features --features fake
+  - cargo clean
   - cargo build --verbose --all-features
   - cargo test --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default = ["fake", "temp"]
 fake = []
 mock = ["pseudo"]
 temp = ["rand", "tempdir"]
-testing = ["mock", "fake"]
+testing = ["temp", "fake"]
 
 [dependencies]
 pseudo = { version = "^0.1.0", optional = true }

--- a/src/fake/mod.rs
+++ b/src/fake/mod.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::ffi::{OsStr, OsString};
 use std::io::Result;
 use std::iter::Iterator;
@@ -298,7 +297,7 @@ impl TempFileSystem for FakeFileSystem {
     type TempDir = FakeTempDir;
 
     fn temp_dir<S: AsRef<str>>(&self, prefix: S) -> Result<Self::TempDir> {
-        let base = env::temp_dir();
+        let base = std::env::temp_dir();
         let dir = FakeTempDir::new(Arc::downgrade(&self.registry), &base, prefix.as_ref());
 
         self.create_dir_all(&dir.path()).and(Ok(dir))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::io::Result;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "fake")]
-pub use fake::{FakeFileSystem, FakeTempDir};
+pub use fake::{FakeFileSystem};
 #[cfg(any(feature = "mock", test))]
 pub use mock::{FakeError, MockFileSystem};
 pub use os::OsFileSystem;


### PR DESCRIPTION
Users currently cannot use the `fake` feature on its own. This PR fixes this.
```toml
[dependencies.filesystem]
version = "0.4.4"
default-features = false
features = ["fake"]
```
```
Compiling filesystem v0.4.4
error[E0432]: unresolved import `fake::FakeTempDir`
  --> /home/sva/.cargo/registry/src/github.com-1ecc6299db9ec823/filesystem-0.4.4/src/lib.rs:13:32
   |
13 | pub use fake::{FakeFileSystem, FakeTempDir};
   |                                ^^^^^^^^^^^ no `FakeTempDir` in `fake`

error: aborting due to previous error
```