### PR TITLE
Add symlink support to UnixFileSystem trait

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Symlink test",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=symlink",
+        ]
+      },
+      "program": "${cargo:program}",
+      "args": []
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "FS test",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=fs",
+        ]
+      },
+      "program": "${cargo:program}",
+      "args": []
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.watcherExclude": {
+    "**/target": true
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "files.watcherExclude": {
     "**/target": true
-  }
+  },
+  "rust-client.channel": "nightly"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ test = false
 name = "fs"
 required-features = ["fake", "temp"]
 
+[[test]]
+name = "symlink"
+required-features = ["fake", "temp"]
+
 [features]
 default = ["fake", "temp"]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/fake/mod.rs
+++ b/src/fake/mod.rs
@@ -297,6 +297,10 @@ impl UnixFileSystem for FakeFileSystem {
             r.symlink(src, dst)
         })
     }
+
+    fn get_symlink_src<P: AsRef<Path>>(&self, dst: P) -> Result<PathBuf> {
+        return self.apply(dst.as_ref(), |r, p| r.read_link(p));
+    }
 }
 
 #[cfg(feature = "temp")]

--- a/src/fake/mod.rs
+++ b/src/fake/mod.rs
@@ -291,6 +291,12 @@ impl UnixFileSystem for FakeFileSystem {
     fn set_mode<P: AsRef<Path>>(&self, path: P, mode: u32) -> Result<()> {
         self.apply_mut(path.as_ref(), |r, p| r.set_mode(p, mode))
     }
+
+    fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> Result<()> {
+        self.apply_mut_from_to(src.as_ref(), dst.as_ref(), |r, src, dst| {
+            r.symlink(src, dst)
+        })
+    }
 }
 
 #[cfg(feature = "temp")]

--- a/src/fake/node.rs
+++ b/src/fake/node.rs
@@ -1,3 +1,6 @@
+use crate::fake::registry::Registry;
+use std::path::PathBuf;
+
 #[derive(Debug, Clone)]
 pub struct File {
     pub contents: Vec<u8>,
@@ -24,23 +27,41 @@ impl Dir {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct Symlink {
+    pub mode: u32,
+    pub source: PathBuf,
+}
+
+impl Symlink {
+    pub fn new(source: PathBuf) -> Self {
+        Symlink {
+            mode: 0o644,
+            source,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Node {
     File(File),
     Dir(Dir),
+    Symlink(Symlink),
 }
 
 impl Node {
-    pub fn is_file(&self) -> bool {
-        match *self {
+    pub fn is_file(&self, registry: &Registry) -> bool {
+        match &*self {
             Self::File(_) => true,
+            Self::Symlink(symlink) => registry.is_file(&symlink.source),
             _ => false,
         }
     }
 
-    pub fn is_dir(&self) -> bool {
-        match *self {
+    pub fn is_dir(&self, registry: &Registry) -> bool {
+        match &*self {
             Self::Dir(_) => true,
+            Self::Symlink(symlink) => registry.is_dir(&symlink.source),
             _ => false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,9 @@ pub trait UnixFileSystem {
     ///
     /// [`std::os::unix::fs::symlink`]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
     fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> Result<()>;
+
+    ///
+    fn get_symlink_src<P: AsRef<Path>>(&self, dst: P) -> Result<PathBuf>;
 }
 
 #[cfg(feature = "temp")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(io_error_more)]
+
 #[cfg(any(feature = "mock", test))]
 extern crate pseudo;
 #[cfg(feature = "temp")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,8 +210,9 @@ pub trait UnixFileSystem {
     ///
     /// [`std::os::unix::fs::symlink`]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
     fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> Result<()>;
-
-    ///
+    /// Gets the source for a symlink.
+    /// 
+    /// Based on [`std::fs::read_link`]
     fn get_symlink_src<P: AsRef<Path>>(&self, dst: P) -> Result<PathBuf>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,14 @@ pub trait UnixFileSystem {
     /// * `path` does not exist.
     /// * Current user has insufficient permissions.
     fn set_mode<P: AsRef<Path>>(&self, path: P, mode: u32) -> Result<()>;
+    /// Creates a new symbolic link on the filesystem.
+    ///
+    /// The `dst` path will be a symbolic link pointing to the `src` path.
+    ///
+    /// Based on [`std::os::unix::fs::symlink`].
+    ///
+    /// [`std::os::unix::fs::symlink`]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
+    fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> Result<()>;
 }
 
 #[cfg(feature = "temp")]

--- a/src/os.rs
+++ b/src/os.rs
@@ -202,6 +202,9 @@ impl UnixFileSystem for OsFileSystem {
 
         fs::set_permissions(path, permissions)
     }
+    fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> Result<()> {
+        std::os::unix::fs::symlink(src, dst)
+    }
 }
 
 #[cfg(feature = "temp")]

--- a/src/os.rs
+++ b/src/os.rs
@@ -205,6 +205,10 @@ impl UnixFileSystem for OsFileSystem {
     fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(&self, src: P, dst: Q) -> Result<()> {
         std::os::unix::fs::symlink(src, dst)
     }
+
+    fn get_symlink_src<P: AsRef<Path>>(&self, dst: P) -> Result<PathBuf> {
+        std::fs::read_link(dst)
+    }
 }
 
 #[cfg(feature = "temp")]

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1,3 +1,4 @@
+#![feature(io_error_more)]
 extern crate filesystem;
 
 #[macro_use]
@@ -151,7 +152,7 @@ fn set_current_dir_fails_if_node_is_a_file<T: FileSystem>(fs: &T, parent: &Path)
     let result = fs.set_current_dir(path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NotADirectory);
 }
 
 fn is_dir_returns_true_if_node_is_dir<T: FileSystem>(fs: &T, parent: &Path) {
@@ -281,7 +282,7 @@ fn remove_dir_fails_if_node_is_a_file<T: FileSystem>(fs: &T, parent: &Path) {
     let result = fs.remove_dir(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NotADirectory);
     assert!(fs.is_file(&path));
 }
 
@@ -295,7 +296,7 @@ fn remove_dir_fails_if_dir_is_not_empty<T: FileSystem>(fs: &T, parent: &Path) {
     let result = fs.remove_dir(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::DirectoryNotEmpty);
     assert!(fs.is_dir(&path));
     assert!(fs.is_file(&child));
 }
@@ -323,7 +324,7 @@ fn remove_dir_all_fails_if_node_is_a_file<T: FileSystem>(fs: &T, parent: &Path) 
     let result = fs.remove_dir_all(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NotADirectory);
     assert!(fs.is_file(&path));
 }
 
@@ -448,7 +449,7 @@ fn read_dir_fails_if_node_is_a_file<T: FileSystem>(fs: &T, parent: &Path) {
     assert!(result.is_err());
     match result {
         Ok(_) => panic!("should be an err"),
-        Err(err) => assert_eq!(err.kind(), ErrorKind::Other),
+        Err(err) => assert_eq!(err.kind(), ErrorKind::NotADirectory),
     }
 }
 
@@ -497,7 +498,7 @@ fn write_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &Path)
     let result = fs.write_file(&path, "test contents");
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::IsADirectory);
 }
 
 fn overwrite_file_overwrites_contents_of_existing_file<T: FileSystem>(fs: &T, parent: &Path) {
@@ -542,7 +543,7 @@ fn overwrite_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &P
     let result = fs.overwrite_file(&path, "test contents");
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::IsADirectory);
 }
 
 fn read_file_returns_contents_as_bytes<T: FileSystem>(fs: &T, parent: &Path) {
@@ -751,7 +752,7 @@ fn copy_file_fails_if_destination_node_is_directory<T: FileSystem>(fs: &T, paren
     let result = fs.copy_file(&from, &to);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::IsADirectory);
 }
 
 fn rename_renames_a_file<T: FileSystem>(fs: &T, parent: &Path) {
@@ -877,12 +878,12 @@ fn rename_fails_if_original_and_destination_are_different_types<T: FileSystem>(
     let result = fs.rename(&file, &dir);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::IsADirectory);
 
     let result = fs.rename(&dir, &file);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NotADirectory);
 }
 
 fn rename_fails_if_destination_directory_is_not_empty<T: FileSystem>(fs: &T, parent: &Path) {

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1,23 +1,14 @@
 extern crate filesystem;
 
+#[macro_use]
+mod utils;
+
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 use filesystem::UnixFileSystem;
 use filesystem::{DirEntry, FakeFileSystem, FileSystem, OsFileSystem, TempDir, TempFileSystem};
-
-macro_rules! make_test {
-    ($test:ident, $fs:expr) => {
-        #[test]
-        fn $test() {
-            let fs = $fs();
-            let temp_dir = fs.temp_dir("test").unwrap();
-
-            super::$test(&fs, temp_dir.path());
-        }
-    };
-}
 
 macro_rules! test_fs {
     ($name:ident, $fs:expr) => {

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -678,7 +678,6 @@ fn remove_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &Path
     let result = fs.remove_file(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 }
 
 fn copy_file_copies_a_file<T: FileSystem>(fs: &T, parent: &Path) {

--- a/tests/symlink.rs
+++ b/tests/symlink.rs
@@ -1,0 +1,551 @@
+#![cfg(unix)]
+///! This file contains tests for the symlink functionality. Since it's only supported on 
+///! objects that implement the `UnixFileSystem` trait, this whole file is restricted to
+///! the Unix configuration.
+extern crate filesystem;
+
+#[macro_use]
+mod utils;
+
+use std::io::ErrorKind;
+use std::path::{PathBuf,Path};
+
+use filesystem::UnixFileSystem;
+use filesystem::{DirEntry, FakeFileSystem, FileSystem, OsFileSystem, TempDir, TempFileSystem};
+
+macro_rules! test_fs {
+    ($name:ident, $fs:expr) => {
+        mod $name {
+            use super::*;
+
+            make_test!(set_current_dir_fails_if_node_is_broken_symlink, $fs);
+            make_test!(set_current_dir_fails_if_node_is_file_symlink, $fs);
+
+            make_test!(is_dir_returns_true_if_node_is_dir_symlink, $fs);
+            make_test!(is_dir_returns_false_if_node_is_file_symlink, $fs);
+            make_test!(is_dir_returns_false_if_node_is_broken_symlink, $fs);
+
+            make_test!(is_file_returns_true_if_node_is_file_symlink, $fs);
+            make_test!(is_file_returns_false_if_node_is_dir, $fs);
+            make_test!(is_file_returns_false_if_node_is_broken_symlink, $fs);
+
+            make_test!(symlink_fails_if_something_already_exists, $fs);
+            make_test!(create_dir_fails_if_parent_is_broken_symlink, $fs);
+
+            make_test!(create_dir_and_create_file_succeed_inside_symlink_source, $fs);
+            make_test!(create_dir_and_create_file_fail_in_file_symlink, $fs);
+
+            make_test!(remove_file_deletes_only_dir_symlink, $fs);
+            make_test!(remove_file_deletes_only_file_symlink, $fs);
+
+            make_test!(remove_dir_fails_if_node_is_broken_symlink, $fs);
+            make_test!(remove_dir_fails_if_node_is_file_symlink, $fs);
+            make_test!(remove_dir_fails_if_node_is_dir_symlink, $fs);
+            
+            make_test!(remove_dir_inside_symlink_works, $fs);
+            make_test!(remove_dir_all_inside_symlink_works, $fs);
+            make_test!(remove_file_inside_symlink_works, $fs);
+
+            make_test!(read_dir_fails_if_node_is_broken_symlink, $fs);
+
+            make_test!(write_file_writes_to_new_file_inside_symlink, $fs);
+            make_test!(write_file_overwrites_contents_of_existing_file_inside_symlink, $fs);
+            make_test!(write_file_overwrites_contents_of_symlink_source_file, $fs);
+
+            make_test!(read_file_returns_symlink_source_contents, $fs);
+            make_test!(read_file_works_inside_symlink, $fs);
+            make_test!(read_file_fails_if_node_is_broken_symlink, $fs);
+            
+            make_test!(create_file_writes_to_new_file_inside_symlink, $fs);
+            
+            make_test!(copy_file_copies_a_file_from_symlink, $fs);
+            make_test!(copy_file_copies_a_file_from_inside_symlink, $fs);
+            make_test!(copy_file_copies_a_file_to_inside_symlink, $fs);
+            make_test!(copy_file_fails_if_original_file_is_broken_symlink, $fs);
+
+            make_test!(rename_renames_a_symlink, $fs);        }
+    };
+}
+
+#[cfg(unix)]
+test_fs!(os, OsFileSystem::new);
+#[cfg(unix)]
+test_fs!(fake, FakeFileSystem::new);
+
+fn set_current_dir_fails_if_node_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+  let path = parent.join("file");
+  let link_path = parent.join("file_link");
+
+  fs.symlink(&path, &link_path).unwrap();
+
+  let result = fs.set_current_dir(&link_path);
+
+  assert!(result.is_err());
+  assert_eq!(result.unwrap_err().kind(), ErrorKind::NotFound);
+}
+
+fn set_current_dir_fails_if_node_is_file_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+  let path = parent.join("file");
+  fs.create_file(&path, "").unwrap();
+  
+  let link_path = parent.join("file_link");
+  fs.symlink(&path, &link_path).unwrap();
+
+  let result = fs.set_current_dir(&link_path);
+
+  assert!(result.is_err());
+  assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+}
+
+fn is_dir_returns_true_if_node_is_dir_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("new_dir");
+    fs.create_dir(&path).unwrap();
+    
+    let link_path = parent.join("link");
+    fs.symlink(&path, &link_path).unwrap();
+
+    assert!(fs.is_dir(&link_path));
+}
+
+fn is_dir_returns_false_if_node_is_file_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("new_file");
+    fs.create_file(&path, "").unwrap();
+    
+    let link_path = parent.join("link");
+    fs.symlink(&path, &link_path).unwrap();
+
+    assert!(!fs.is_dir(&link_path));
+}
+
+fn is_dir_returns_false_if_node_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("new_dir");
+    let link_path = parent.join("link");
+
+    fs.symlink(&path, &link_path).unwrap();
+
+    assert!(!fs.is_dir(parent.join("link")));
+}
+
+fn is_file_returns_true_if_node_is_file_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("new_file");
+
+    fs.create_file(&path, "").unwrap();
+    
+    let link_path = parent.join("link");
+    fs.symlink(&path, &link_path).unwrap();
+
+    assert!(fs.is_file(&link_path));
+}
+
+fn is_file_returns_false_if_node_is_dir<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("new_dir");
+
+    fs.create_dir(&path).unwrap();
+
+    let link_path = parent.join("link");
+    fs.symlink(&path, &link_path).unwrap();
+
+    assert!(!fs.is_file(&link_path));
+}
+
+fn is_file_returns_false_if_node_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let link_path = parent.join("link");
+    fs.symlink(parent.join("404"), &link_path).unwrap();
+
+    assert!(!fs.is_file(&link_path));
+}
+
+fn symlink_fails_if_something_already_exists<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let file_path = parent.join("file");
+    let dir_path = parent.join("dir");
+    let symlink_file_path = parent.join("symlink_file");
+    let symlink_dir_path = parent.join("symlink_dir");
+    let symlink_broken_path = parent.join("symlink_broken");
+    let dummy_path = parent.join("dummy");
+
+    fs.create_dir(&dir_path).unwrap();
+    fs.create_file(&file_path, "").unwrap();
+    fs.symlink(&dir_path, &symlink_dir_path).unwrap();
+    fs.symlink(&file_path, &symlink_file_path).unwrap();
+    fs.symlink(&parent.join("404"), &symlink_broken_path).unwrap();
+
+    let used_paths = [&file_path, &dir_path, &symlink_dir_path, &symlink_broken_path, &symlink_file_path];
+    for path in used_paths.iter() {
+        let result = fs.symlink(&dummy_path, path);
+        assert!(result.is_err(), "Could create symlink {:?}, that contained another dir/file/symlink", path);
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::AlreadyExists);
+    }
+}
+
+fn create_dir_fails_if_parent_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("parent/new_dir");
+    let link_path = parent.join("parent");
+    fs.symlink(parent.join("404"), &link_path).unwrap();
+
+    let result = fs.create_dir(&path);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NotFound);
+}
+
+fn create_dir_and_create_file_succeed_inside_symlink_source<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir_path = parent.join("link/new_dir");
+    let file_path = parent.join("link/file_dir");
+    let link_path = parent.join("link");
+    let source_path = parent.join("real_dir");
+    let real_dir_path = parent.join("real_dir/new_dir");
+    let real_file_path = parent.join("real_dir/new_dir");
+    
+    fs.create_dir(&source_path).unwrap();
+
+    fs.symlink(&source_path, &link_path).unwrap();
+
+    fs.create_dir(&dir_path).unwrap();
+    fs.create_file(&file_path, "").unwrap();
+
+    assert!(fs.is_dir(real_dir_path));
+    assert!(fs.is_dir(real_file_path));
+}
+
+fn create_dir_and_create_file_fail_in_file_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir_path = parent.join("link/new_dir");
+    let file_path = parent.join("link/file");
+    let link_path = parent.join("link");
+    let source_path = parent.join("file");
+    fs.create_file(&source_path, "").unwrap();
+    fs.symlink(&source_path, &link_path).unwrap();
+
+    let result = fs.create_dir(&dir_path);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    
+    let result = fs.create_file(&file_path, "");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+}
+
+fn remove_file_deletes_only_dir_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("dir");
+    let link = parent.join("link");
+
+    fs.create_dir(&path).unwrap();
+    fs.symlink(&path, &link).unwrap();
+
+    assert!(fs.is_dir(&path));
+    assert!(fs.is_dir(&link));
+
+    fs.remove_file(&link).unwrap();
+
+    assert!(fs.is_dir(&path));
+    assert!(!fs.is_dir(&link));
+}
+
+fn remove_file_deletes_only_file_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("file");
+    let link = parent.join("link");
+    fs.create_file(&path, "").unwrap();
+    fs.symlink(&path, &link).unwrap();
+
+    assert!(fs.is_file(&path));
+    assert!(fs.is_file(&link));
+
+    fs.remove_file(&link).unwrap();
+
+    assert!(fs.is_file(&path));
+    assert!(!fs.is_file(&link));
+}
+
+fn remove_dir_fails_if_node_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let broken_symlink = parent.join("broken_symlink");
+    let nonexistent_source = parent.join("source");
+    fs.symlink(&nonexistent_source, &broken_symlink).unwrap();
+
+    let result = fs.remove_dir(&broken_symlink);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+}
+
+fn remove_dir_fails_if_node_is_file_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("file");
+    let symlink = parent.join("symlink");
+
+    fs.create_file(&path, "").unwrap();
+    fs.symlink(&path, &symlink).unwrap();
+
+    let result = fs.remove_dir(&symlink);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert!(fs.is_file(&symlink));
+}
+
+fn remove_dir_fails_if_node_is_dir_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    // Symlinks are only deleted with std::remove_file, std::remove_dir fails.
+    let path = parent.join("dir");
+    let symlink = parent.join("symlink");
+
+    fs.create_dir(&path).unwrap();
+    fs.symlink(&path, &symlink).unwrap();
+
+    let result = fs.remove_dir(&symlink);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+    assert!(fs.is_dir(&symlink));
+}
+
+fn remove_dir_inside_symlink_works<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir1 = parent.join("dir");
+    let dir2 = dir1.join("dir");
+    let link = parent.join("link");
+
+    fs.create_dir(&dir1).unwrap();
+    fs.create_dir(&dir2).unwrap();
+    fs.symlink(&dir1, &link).unwrap();
+
+    let result = fs.remove_dir(link.join("dir"));
+
+    assert!(result.is_ok());
+    assert!(fs.is_dir(&dir1));
+    assert!(fs.is_dir(&link));
+    assert!(!fs.is_dir(&dir2));
+}
+
+fn remove_dir_all_inside_symlink_works<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir1 = parent.join("dir");
+    let dir2 = dir1.join("dir");
+    let file = dir2.join("file");
+    let link = parent.join("link");
+
+    fs.create_dir(&dir1).unwrap();
+    fs.create_dir(&dir2).unwrap();
+    fs.create_file(&file, "").unwrap();
+    fs.symlink(&dir1, &link).unwrap();
+
+    let result = fs.remove_dir_all(link.join("dir"));
+
+    assert!(result.is_ok());
+    assert!(fs.is_dir(&dir1));
+    assert!(fs.is_dir(&link));
+    assert!(!fs.is_dir(&dir2));
+    assert!(!fs.is_file(&file));
+}
+
+fn remove_file_inside_symlink_works<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir = parent.join("dir");
+    let file = dir.join("file");
+    let link = parent.join("link");
+
+    fs.create_dir(&dir).unwrap();
+    fs.create_file(&file, "").unwrap();
+    fs.symlink(&dir, &link).unwrap();
+
+    let result = fs.remove_file(link.join("file"));
+
+    assert!(result.is_ok());
+    assert!(fs.is_dir(&dir));
+    assert!(fs.is_dir(&link));
+    assert!(!fs.is_file(&file));
+}
+
+fn read_dir_fails_if_node_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("broken_symlink");
+    let result = fs.read_dir(&path);
+
+    assert!(result.is_err());
+
+    match result {
+        Ok(_) => panic!("should be an err"),
+        Err(err) => assert_eq!(err.kind(), ErrorKind::NotFound),
+    }
+}
+
+fn write_file_writes_to_new_file_inside_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir = parent.join("dir");
+    let link = parent.join("link");
+    let file = link.join("file");
+    let real_file = dir.join("file");
+
+    fs.create_dir(&dir).unwrap();
+    fs.symlink(&dir, &link).unwrap();
+    fs.write_file(&file, "file").unwrap();
+
+    assert!(fs.is_file(&file));
+    assert!(fs.is_file(&real_file));
+
+    assert_eq!(fs.read_file_to_string(&file).unwrap(), fs.read_file_to_string(&real_file).unwrap());
+}
+
+fn write_file_overwrites_contents_of_existing_file_inside_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir = parent.join("dir");
+    let link = parent.join("link");
+    let file = link.join("file");
+    let real_file = dir.join("file");
+    let contents = "some random content";
+
+    fs.create_dir(&dir).unwrap();
+    fs.symlink(&dir, &link).unwrap();
+    fs.create_file(&file, "").unwrap();
+    fs.write_file(&file, contents).unwrap();
+
+    assert!(fs.is_file(&file));
+    assert!(fs.is_file(&real_file));
+
+    assert_eq!(contents, fs.read_file_to_string(&real_file).unwrap());
+    assert_eq!(contents, fs.read_file_to_string(&file).unwrap());
+}
+
+fn write_file_overwrites_contents_of_symlink_source_file<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let link = parent.join("link");
+    let file = parent.join("file");
+    let contents = "some random content";
+
+    fs.create_file(&file, "").unwrap();
+    fs.symlink(&file, &link).unwrap();
+    fs.write_file(&link, contents).unwrap();
+
+    assert!(fs.is_file(&file));
+    assert!(fs.is_file(&link));
+
+    assert_eq!(contents, fs.read_file_to_string(&file).unwrap());
+    assert_eq!(contents, fs.read_file_to_string(&link).unwrap());
+}
+
+fn read_file_returns_symlink_source_contents<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let file = parent.join("test.txt");
+    let link = parent.join("link");
+
+    let contents = "some random content";
+
+    fs.write_file(&file, contents).unwrap();
+    fs.symlink(&file, &link).unwrap();
+
+    assert!(fs.is_file(&file));
+    assert!(fs.is_file(&link));
+
+    assert_eq!(contents, fs.read_file_to_string(&file).unwrap());
+    assert_eq!(contents, fs.read_file_to_string(&link).unwrap());
+}
+
+fn read_file_works_inside_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir = parent.join("dir");
+    let file = dir.join("test.txt");
+    let link = parent.join("link");
+    let linked_file = link.join("test.txt");
+
+    let contents = "some random content";
+
+    fs.create_dir(&dir).unwrap();
+    fs.write_file(&file, contents).unwrap();
+    fs.symlink(&dir, &link).unwrap();
+
+    assert!(fs.is_file(&file));
+    assert!(fs.is_file(&linked_file));
+
+    assert_eq!(contents, fs.read_file_to_string(&file).unwrap());
+    assert_eq!(contents, fs.read_file_to_string(&linked_file).unwrap());
+}
+
+fn read_file_fails_if_node_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let link = parent.join("test.txt");
+
+    fs.symlink(parent.join("file"), &link).unwrap();
+    
+    let result = fs.read_file(&link);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NotFound);
+}
+
+fn create_file_writes_to_new_file_inside_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir = parent.join("dir");
+    let link = parent.join("link");
+    let file = link.join("file");
+    let real_file = dir.join("file");
+
+    fs.create_dir(&dir).unwrap();
+    fs.symlink(&dir, &link).unwrap();
+    fs.create_file(&file, "file").unwrap();
+
+    assert!(fs.is_file(&file));
+    assert!(fs.is_file(&real_file));
+
+    assert_eq!(fs.read_file_to_string(&file).unwrap(), fs.read_file_to_string(&real_file).unwrap());
+}
+
+fn copy_file_copies_a_file_from_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let file = parent.join("file");
+    let link = parent.join("link");
+    let to = parent.join("to");
+
+    let contents = "some random content";
+
+    fs.create_file(&file, &contents).unwrap();
+    fs.symlink(&file, &link).unwrap();
+
+    fs.copy_file(&link, &to).unwrap();
+
+    assert_eq!(contents, fs.read_file_to_string(&to).unwrap());
+}
+
+fn copy_file_copies_a_file_from_inside_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir = parent.join("dir");
+    let link = parent.join("link");
+    let file = dir.join("file");
+    let from = link.join("file");
+    let to = parent.join("to");
+
+    let contents = "some random content";
+
+    fs.create_dir(&dir).unwrap();
+    fs.create_file(&file, &contents).unwrap();
+    fs.symlink(&dir, &link).unwrap();
+
+    fs.copy_file(&from, &to).unwrap();
+
+    assert_eq!(contents, fs.read_file_to_string(&to).unwrap());
+}
+
+fn copy_file_copies_a_file_to_inside_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let dir = parent.join("dir");
+    let link = parent.join("link");
+    let from = parent.join("file");
+    let to = link.join("file");
+
+    let contents = "some random content";
+
+    fs.create_dir(&dir).unwrap();
+    fs.create_file(&from, &contents).unwrap();
+    fs.symlink(&dir, &link).unwrap();
+
+    fs.copy_file(&from, &to).unwrap();
+
+    assert_eq!(contents, fs.read_file_to_string(&from).unwrap());
+    assert_eq!(contents, fs.read_file_to_string(&to).unwrap());
+    assert_eq!(contents, fs.read_file_to_string(&dir.join("file")).unwrap());
+}
+
+fn copy_file_fails_if_original_file_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let from = parent.join("from");
+    let to = parent.join("to");
+
+    let result = fs.copy_file(&from, &to);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NotFound);
+    assert!(!fs.is_file(&to));
+}
+
+fn rename_renames_a_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
+    let from = parent.join("from");
+    let to = parent.join("to");
+
+    fs.symlink(parent.join("somefile"), &from).unwrap();
+
+    fs.rename(&from, &to).unwrap();
+    
+    let mut entries: Vec<PathBuf> = fs.read_dir(&parent).unwrap().map(|e| e.unwrap().path()).collect();
+    assert_eq!(1, entries.len());
+    assert_eq!(to, entries[0]);
+}

--- a/tests/symlink.rs
+++ b/tests/symlink.rs
@@ -38,7 +38,6 @@ macro_rules! test_fs {
             make_test!(remove_file_deletes_only_dir_symlink, $fs);
             make_test!(remove_file_deletes_only_file_symlink, $fs);
 
-            make_test!(remove_dir_fails_if_node_is_broken_symlink, $fs);
             make_test!(remove_dir_fails_if_node_is_file_symlink, $fs);
             make_test!(remove_dir_fails_if_node_is_dir_symlink, $fs);
             
@@ -253,17 +252,6 @@ fn remove_file_deletes_only_file_symlink<T: UnixFileSystem + FileSystem>(fs: &T,
 
     assert!(fs.is_file(&path));
     assert!(!fs.is_file(&link));
-}
-
-fn remove_dir_fails_if_node_is_broken_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
-    let broken_symlink = parent.join("broken_symlink");
-    let nonexistent_source = parent.join("source");
-    fs.symlink(&nonexistent_source, &broken_symlink).unwrap();
-
-    let result = fs.remove_dir(&broken_symlink);
-
-    assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 }
 
 fn remove_dir_fails_if_node_is_file_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Path) {
@@ -541,11 +529,11 @@ fn rename_renames_a_symlink<T: UnixFileSystem + FileSystem>(fs: &T, parent: &Pat
     let from = parent.join("from");
     let to = parent.join("to");
 
-    fs.symlink(parent.join("somefile"), &from).unwrap();
+    fs.symlink(parent.join("some_file"), &from).unwrap();
 
     fs.rename(&from, &to).unwrap();
     
-    let mut entries: Vec<PathBuf> = fs.read_dir(&parent).unwrap().map(|e| e.unwrap().path()).collect();
+    let entries: Vec<PathBuf> = fs.read_dir(&parent).unwrap().map(|e| e.unwrap().path()).collect();
     assert_eq!(1, entries.len());
     assert_eq!(to, entries[0]);
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,13 @@
+
+/// Macro to generate a test for a specific filesystem.
+macro_rules! make_test {
+    ($test:ident, $fs:expr) => {
+        #[test]
+        fn $test() {
+            let fs = $fs();
+            let temp_dir = fs.temp_dir("test").unwrap();
+
+            super::$test(&fs, temp_dir.path());
+        }
+    };
+  }


### PR DESCRIPTION
This is a large change since it means adding a new Node type and all the
corresponding exhaustive matches. I copied the behavior from macOS 11:
A symlink is treated as a file if it ultimately points to a file, and a
Symlynk is treated as a directory if it points to a directory. If
recursing gets you to a broken symlink then it is treated as neither.