### PR TITLE
include exists

### DIFF
--- a/src/fake/mod.rs
+++ b/src/fake/mod.rs
@@ -126,6 +126,10 @@ impl FileSystem for FakeFileSystem {
         self.apply(path.as_ref(), |r, p| r.is_file(p))
     }
 
+    fn exists<P: AsRef<Path>>(&self, path: P) -> bool {
+        self.apply(path.as_ref(), |r, p| r.exists(p))
+    }
+
     fn create_dir<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         self.apply_mut(path.as_ref(), |r, p| r.create_dir(p))
     }

--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -42,6 +42,10 @@ impl Registry {
         self.get(path).map(Node::is_file).unwrap_or(false)
     }
 
+    pub fn exists(&self, path: &Path) -> bool {
+        self.get(path).and(Ok(true)).unwrap_or(false)
+    }
+
     pub fn create_dir(&mut self, path: &Path) -> Result<()> {
         self.insert(path.to_path_buf(), Node::Dir(Dir::new()))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ pub trait FileSystem {
     /// Determines whether the path exists and points to a file.
     fn is_file<P: AsRef<Path>>(&self, path: P) -> bool;
 
+    fn exists<P: AsRef<Path>>(&self, path: P) -> bool;
+
     /// Creates a new directory.
     /// This is based on [`std::fs::create_dir`].
     ///

--- a/src/os.rs
+++ b/src/os.rs
@@ -65,6 +65,10 @@ impl FileSystem for OsFileSystem {
         path.as_ref().is_file()
     }
 
+    fn exists<P: AsRef<Path>>(&self, path: P) -> bool {
+        path.as_ref().exists()
+    }
+
     fn create_dir<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         fs::create_dir(path)
     }

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -35,6 +35,10 @@ macro_rules! test_fs {
             make_test!(is_file_returns_false_if_node_is_dir, $fs);
             make_test!(is_file_returns_false_if_node_does_not_exist, $fs);
 
+            make_test!(exists_returns_true_if_node_is_file, $fs);
+            make_test!(exists_returns_true_if_node_is_directory, $fs);
+            make_test!(exists_returns_false_if_node_does_not_exist, $fs);
+
             make_test!(create_dir_creates_new_dir, $fs);
             make_test!(create_dir_fails_if_dir_already_exists, $fs);
             make_test!(create_dir_fails_if_parent_does_not_exist, $fs);
@@ -201,6 +205,26 @@ fn is_file_returns_false_if_node_is_dir<T: FileSystem>(fs: &T, parent: &Path) {
 
 fn is_file_returns_false_if_node_does_not_exist<T: FileSystem>(fs: &T, parent: &Path) {
     assert!(!fs.is_file(parent.join("does_not_exist")));
+}
+
+fn exists_returns_false_if_node_does_not_exist<T: FileSystem>(fs: &T, parent: &Path) {
+    assert!(!fs.exists(parent.join("does_not_exist")));
+}
+
+fn exists_returns_true_if_node_is_file<T: FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("new_file");
+
+    fs.create_dir(&path).unwrap();
+
+    assert!(fs.exists(&path));
+}
+
+fn exists_returns_true_if_node_is_directory<T: FileSystem>(fs: &T, parent: &Path) {
+    let path = parent.join("new_dir");
+
+    fs.create_dir(&path).unwrap();
+
+    assert!(fs.exists(&path));
 }
 
 fn create_dir_creates_new_dir<T: FileSystem>(fs: &T, parent: &Path) {


### PR DESCRIPTION
Add the exists function to the trait, which simulate the `std::path::Path::exists` function. This is useful when working with node which are not a file or a directory. Our use case is the a device node, like `/dev/sda`. is_file return false since the node is not a regular file. For those who are looking for a work around, we are currently using the `mode` function and check the return with `is_ok`, it is a bit hacky, but works for us.