### PR TITLE
Remove vulnerabilities indicated by cargo audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,17 +31,16 @@ default = ["fake", "temp"]
 
 fake = []
 mock = ["pseudo"]
-temp = ["rand", "tempdir"]
+temp = ["rand", "tempfile"]
 testing = ["mock", "fake"]
 
 [dependencies]
 pseudo = { version = "^0.1.0", optional = true }
 rand = { version = "^0.4", optional = true }
-tempdir = { version = "^0.3", optional = true }
+tempfile = { version = "^3.5.0", optional = true }
 
 [dev-dependencies]
 pseudo = "^0.1.0"
-tempdir = "^0.3"
 
 [badges]
 travis-ci = { repository = "iredelmeier/filesystem-rs" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate pseudo;
 #[cfg(feature = "temp")]
 extern crate rand;
 #[cfg(feature = "temp")]
-extern crate tempdir;
+extern crate tempfile;
 
 use std::ffi::OsString;
 use std::io::Result;

--- a/src/os.rs
+++ b/src/os.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "temp")]
-use tempdir;
+use tempfile;
 
 #[cfg(unix)]
 use UnixFileSystem;
@@ -22,7 +22,7 @@ use {TempDir, TempFileSystem};
 /// [`TempDir`]: https://doc.rust-lang.org/tempdir/tempdir/struct.TempDir.html
 #[cfg(feature = "temp")]
 #[derive(Debug)]
-pub struct OsTempDir(tempdir::TempDir);
+pub struct OsTempDir(tempfile::TempDir);
 
 #[cfg(feature = "temp")]
 impl TempDir for OsTempDir {
@@ -209,7 +209,10 @@ impl TempFileSystem for OsFileSystem {
     type TempDir = OsTempDir;
 
     fn temp_dir<S: AsRef<str>>(&self, prefix: S) -> Result<Self::TempDir> {
-        tempdir::TempDir::new(prefix.as_ref()).map(OsTempDir)
+        tempfile::Builder::new()
+            .prefix(prefix.as_ref())
+            .tempdir()
+            .map(OsTempDir)
     }
 }
 

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -160,7 +160,6 @@ fn set_current_dir_fails_if_node_is_a_file<T: FileSystem>(fs: &T, parent: &Path)
     let result = fs.set_current_dir(path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 }
 
 fn is_dir_returns_true_if_node_is_dir<T: FileSystem>(fs: &T, parent: &Path) {
@@ -290,7 +289,6 @@ fn remove_dir_fails_if_node_is_a_file<T: FileSystem>(fs: &T, parent: &Path) {
     let result = fs.remove_dir(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
     assert!(fs.is_file(&path));
 }
 
@@ -304,7 +302,6 @@ fn remove_dir_fails_if_dir_is_not_empty<T: FileSystem>(fs: &T, parent: &Path) {
     let result = fs.remove_dir(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
     assert!(fs.is_dir(&path));
     assert!(fs.is_file(&child));
 }
@@ -332,7 +329,6 @@ fn remove_dir_all_fails_if_node_is_a_file<T: FileSystem>(fs: &T, parent: &Path) 
     let result = fs.remove_dir_all(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
     assert!(fs.is_file(&path));
 }
 
@@ -457,7 +453,7 @@ fn read_dir_fails_if_node_is_a_file<T: FileSystem>(fs: &T, parent: &Path) {
     assert!(result.is_err());
     match result {
         Ok(_) => panic!("should be an err"),
-        Err(err) => assert_eq!(err.kind(), ErrorKind::Other),
+        Err(_) => (),
     }
 }
 
@@ -506,7 +502,6 @@ fn write_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &Path)
     let result = fs.write_file(&path, "test contents");
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 }
 
 fn overwrite_file_overwrites_contents_of_existing_file<T: FileSystem>(fs: &T, parent: &Path) {
@@ -551,7 +546,6 @@ fn overwrite_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &P
     let result = fs.overwrite_file(&path, "test contents");
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 }
 
 fn read_file_returns_contents_as_bytes<T: FileSystem>(fs: &T, parent: &Path) {
@@ -678,7 +672,6 @@ fn remove_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &Path
     let result = fs.remove_file(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 }
 
 fn copy_file_copies_a_file<T: FileSystem>(fs: &T, parent: &Path) {
@@ -761,7 +754,6 @@ fn copy_file_fails_if_destination_node_is_directory<T: FileSystem>(fs: &T, paren
     let result = fs.copy_file(&from, &to);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 }
 
 fn rename_renames_a_file<T: FileSystem>(fs: &T, parent: &Path) {
@@ -887,12 +879,10 @@ fn rename_fails_if_original_and_destination_are_different_types<T: FileSystem>(
     let result = fs.rename(&file, &dir);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 
     let result = fs.rename(&dir, &file);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
 }
 
 fn rename_fails_if_destination_directory_is_not_empty<T: FileSystem>(fs: &T, parent: &Path) {


### PR DESCRIPTION
## Motivation

* Vulnerabilities have been reported with the dependencies of the `tempdir` crate.
* The `tempdir` crate is also deprecated.

## Change in this PR

* Move to `tempfile` crate, which now contains the latest version of the `tempdir` crate.
* Remove ErrorKind::Other from tests. This enum value is being deprecated in favour of more specific ErrorKinds which are not yet stable. See: https://github.com/rust-lang/rust/issues/86442

